### PR TITLE
fix: use indicatiff from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,8 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.14.0"
-source = "git+https://github.com/mibac138/indicatif?branch=mpb-tick#564c518e8ddea3f1468cd82e054d596fbf4b4e2a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a68371cf417889c9d7f98235b7102ea7c54fc59bcbd22f3dea785be9d27e40"
 dependencies = [
  "console",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ ui = ["indicatif"]
 [dependencies]
 futures = "0.3"
 regex = "1"
-tokio = {version="0.2", features=["tcp", "time", "process", "dns", "rt-threaded", "macros"]}
-indicatif = {git="https://github.com/mibac138/indicatif", branch="mpb-tick", optional=true}
+tokio = {version="0.2", features=["tcp", "time", "process", "dns", "rt-threaded", "macros", "blocking"]}
+indicatif = {version="0.14", optional=true}
 
 [dev-dependencies]
 assert_cmd = "~0.12"

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,4 @@
-use regex;
+use regex::Regex;
 use std::net::IpAddr;
 
 static DOMAIN_REGEX: &str =
@@ -42,7 +42,7 @@ fn validate_domain_and_port(domain_and_port: &str) -> Result<(String, u16), Stri
 
     // check hostname
     let hostname = parts[0].clone();
-    let regex = regex::Regex::new(DOMAIN_REGEX).unwrap();
+    let regex = Regex::new(DOMAIN_REGEX).unwrap();
     let ip: Result<IpAddr, _> = hostname.parse();
 
     if !regex.is_match(&hostname) && ip.is_err() {


### PR DESCRIPTION
Indicatif MultiProgress doesn't work well in the static context
This is basically a workaround for that.
A regular thread is spawned to update the progress in the background.

Note that the code might be refactored to the way it was before.
Once https://github.com/mitsuhiko/indicatif/pull/132 is merged.

closes #26 